### PR TITLE
feat: add check-metas actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf

--- a/.github/actions/check-metas/action.yaml
+++ b/.github/actions/check-metas/action.yaml
@@ -1,0 +1,19 @@
+name: Check all .meta is commited
+description: Check all Unity .meta files are committed.
+inputs:
+  directory:
+    description: Working directory to check change
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.directory }}
+      run: |
+        if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+          echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+          exit 1
+        else
+          echo "Great, all .meta files are commited."
+        fi

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      - ".github/actions/**"
       - ".github/workflows/**"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -109,3 +109,52 @@ jobs:
     with:
       branch: ${{ needs.update-packagejson.outputs.branch-name }}
 ```
+
+
+# Actions
+
+## check-metas
+
+> [See action]((https://github.com/Cysharp/Actions/blob/main/.github/actions/check-meta/action.yaml))
+
+Check Unity .meta files are not generated.
+Mainly used for Unity CI workflow.
+
+**Sample usage**
+
+```yaml
+name: build-debug
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-unity:
+    name: "Build Unity package"
+    strategy:
+      matrix:
+        unity: ["2020.3.33f1"]
+        include:
+          - unity: 2020.3.33f1
+            license: UNITY_LICENSE_2020
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+      # execute scripts/Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets[matrix.license] }}
+        with:
+          buildMethod: PackageExporter.Export
+          versioning: None
+
+      - uses: Cysharp/Actions/.github/actions/check-metas # check meta files
+        with:
+          directory: src/MyProject.Unity
+```


### PR DESCRIPTION
## tl;dr;

check-metas action enable CI to be failed when you forgot commit Unity .meta files.