### PR TITLE
feat: add UNITY_LICENSE mask

### DIFF
--- a/.github/actions/unity-builder/action.yaml
+++ b/.github/actions/unity-builder/action.yaml
@@ -30,6 +30,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Replace last 4 charactors of UNITY_SERIAL and mask it.
+      shell: bash
+      run: echo "::add-mask::"$(echo ${{ env.UNITY_SERIAL }} | sed 's/....$//')XXXX""
     # see: https://github.com/game-ci/unity-builder
     # see: https://game.ci/docs/github/builder/
     - name: Build Unity


### PR DESCRIPTION
## tl;dr;

Mask Unity Serial (masked) in Unity Editor log.

## Summary

Unity Activation log includes UNITY_SERIAL which masked for last 4 characters.

```
# UNITY_SERIAL
abcd-efgh-ijkl-mnop

# UNITY_SERIAL(masked) in Unity Editor log
abcd-efgh-ijkl-XXXX
```