### PR TITLE
feat: Default .NET include 7/8 on setup-dotnet

### DIFF
--- a/.github/actions/setup-dotnet/action.yaml
+++ b/.github/actions/setup-dotnet/action.yaml
@@ -4,7 +4,10 @@ inputs:
   dotnet-version:
     description: .NET SDK versions to install
     required: false
-    default: "6.0"
+    default: |
+      6.x
+      7.x
+      8.x
   dotnet-quality:
     description: "Optional quality of the build. The possible values are: daily, signed, validated, preview, ga."
     required: false


### PR DESCRIPTION
## tl;dr;

.NET 8 LTS is GA. Let's include .NET 7 and 8 as setup-dotnet default.