### PR TITLE
feat: add release upload

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -30,7 +30,7 @@ on:
           ./nuget/*.nupkg
           ./nuget/*.snupkg
       # unity
-      unitypackage-upload:
+      unitypackage-upload: # todo: release-uploadで置き換えられるので消す
         description: "true = upload unitypackage. false = not upload"
         required: false
         type: boolean
@@ -39,8 +39,18 @@ on:
         description: "unitypackage name to upload."
         required: false
         type: string
-      unitypackage-path:
+      unitypackage-path: # todo: release-uploadで置き換えられるので消す
         description: "unitypackage path to upload."
+        required: false
+        type: string
+      # release assets
+      release-upload:
+        description: "true = upload assets. false = not upload"
+        required: false
+        type: boolean
+        default: false
+      release-asset-path:
+        description: "release assets path to upload."
         required: false
         type: string
       dry-run:
@@ -74,6 +84,16 @@ jobs:
       - uses: actions/download-artifact@v3
       - name: Show download aritifacts
         run: ls -lR
+      - name: Validate package exists in artifact - release assets
+        if: ${{ inputs.release-upload }}
+        run: |
+          while read -r asset_path; do
+            if [[ "${asset_path}" == "" ]]; then continue; fi
+            if [[ ! -f "${asset_path}" ]]; then
+              echo "Specified asset not found. path: ${asset_path}"
+              exit 1
+            fi
+          done <<< "${{ inputs.release-asset-path }}"
       - name: Validate package exists in artifact - unitypackage
         if: ${{ inputs.unitypackage-upload }}
         run: |
@@ -105,6 +125,13 @@ jobs:
           git push origin ${{ inputs.tag }}
       - name: Create Release
         run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "Ver.${{ inputs.tag }}" --generate-notes
+      - name: Upload asset files to release
+        run: |
+          while read -r asset_path; do
+            if [[ "${asset_path}" == "" ]]; then continue; fi
+            gh release upload ${{ inputs.tag }} "${asset_path}"
+          done <<< "${{ inputs.release-asset-path }}"
+        if: ${{ inputs.release-upload }}
       - name: Upload .unitypacakge files to release
         run: |
           while read -r unitypackage_path; do

--- a/.github/workflows/test-create-release.yaml
+++ b/.github/workflows/test-create-release.yaml
@@ -22,7 +22,7 @@ jobs:
         ./Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
         ./Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
         ./Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
-      tag: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}"
+      tag: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}"
       dry-run: false
       push-tag: false # tagはcreate-releaseでpushするのでコミットだけさせる。
 
@@ -38,9 +38,9 @@ jobs:
       - name: dotnet restore
         run: dotnet restore
       - name: dotnet build
-        run: dotnet build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}
+        run: dotnet build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}
       - name: dotnet pack
-        run: dotnet pack --no-build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
+        run: dotnet pack --no-build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/create-release.yaml
     with:
       commit-id: ${{ needs.update-packagejson.outputs.sha }}
-      tag: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}"
+      tag: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}"
       dry-run: true # Release作成後に60秒待って削除される。
       nuget-push: true # dry-run なので pushはされない。
       unitypackage-upload: true # Releaseにアップロードされる。
@@ -83,8 +83,8 @@ jobs:
         ./Sandbox.Unity.Plugin.unitypackage/Sandbox.Unity.Plugin.unitypackage
       release-upload: true
       release-asset-path: |
-        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}.nupkg
-        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}.snupkg
+        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}.nupkg
+        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}.snupkg
 
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}

--- a/.github/workflows/test-create-release.yaml
+++ b/.github/workflows/test-create-release.yaml
@@ -38,9 +38,9 @@ jobs:
       - name: dotnet restore
         run: dotnet restore
       - name: dotnet build
-        run: dotnet build -c Release
+        run: dotnet build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}
       - name: dotnet pack
-        run: dotnet pack -c Release --no-build -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
+        run: dotnet pack --no-build -c Release -p:Version=${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
       - name: upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -81,6 +81,10 @@ jobs:
       unitypackage-path: |
         ./Sandbox.Unity.unitypackage/Sandbox.Unity.unitypackage
         ./Sandbox.Unity.Plugin.unitypackage/Sandbox.Unity.Plugin.unitypackage
+      release-upload: true
+      release-asset-path: |
+        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}.nupkg
+        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_id) }}.snupkg
 
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.7802713256"
+version="1.0.42"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.7802554569"
+version="1.0.7802713256"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.7802554569",
+  "version": "1.0.7802713256",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.7802713256",
+  "version": "1.0.42",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.7802713256",
+  "version": "1.0.42",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.7802554569",
+  "version": "1.0.7802713256",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",


### PR DESCRIPTION
add `release-upload` and `release-asset-path`.
```yaml
  create-release:
    needs: [update-packagejson, build-dotnet]
    uses: ./.github/workflows/create-release.yaml
    with:
      commit-id: ${{ needs.update-packagejson.outputs.sha }}
      tag: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}"
      dry-run: true # Release作成後に60秒待って削除される。
      nuget-push: true # dry-run なので pushはされない。
      unitypackage-upload: true # Releaseにアップロードされる。
      unitypackage-path: |
        ./Sandbox.Unity.unitypackage/Sandbox.Unity.unitypackage
        ./Sandbox.Unity.Plugin.unitypackage/Sandbox.Unity.Plugin.unitypackage

      release-upload: true
      release-asset-path: |
        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}.nupkg
        ./nuget/ClassLibrary.${{ github.event_name == 'workflow_dispatch' && inputs.tag || format('1.0.{0}', github.run_number) }}.snupkg
```
![image](https://github.com/Cysharp/Actions/assets/3856350/baabd559-4cf3-4df8-90ee-f4386e88b5ad)
