### PR TITLE
ci: change dawidd6/action-delete-branch to manual delete

### DIFF
--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -25,15 +25,21 @@ jobs:
           fi
 
           # Check if the branch is created by github-actions[bot]
-          if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}"; then
+          if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}" >/dev/null; then
+            echo "branch exists."
+
+            # Check info of the branch
+            gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
+            echo ""
+
             if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
               echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"
-              gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
               exit 1
             fi
 
             branch_deletable=true
           else
+            echo "branch not exists."
             branch_deletable=false
           fi
 

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -14,6 +14,8 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      branch-deleted: ${{ steps.check-branch.outputs.deletable }}
     steps:
       - name: Check branch is deletable
         id: check-branch

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -28,6 +28,7 @@ jobs:
           if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}"; then
             if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
               echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"
+              gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }}
               exit 1
             fi
 

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -26,7 +26,7 @@ jobs:
 
           # Check if the branch is created by github-actions[bot]
           if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}" >/dev/null; then
-            echo "branch exists."
+            echo "branch exists. branch: ${{ inputs.branch }}"
 
             # Check info of the branch
             gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
@@ -39,7 +39,7 @@ jobs:
 
             branch_deletable=true
           else
-            echo "branch not exists."
+            echo "branch not exists. branch: ${{ inputs.branch }}"
             branch_deletable=false
           fi
 

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -7,6 +7,10 @@ on:
         description: "branch name to delete. Only delete branches that are created by github-actions[bot] and are not the default branch."
         required: true
         type: string
+    outputs:
+      branch-deleted:
+        description: "Indicate branch is deleted or not by boolean. true = branch deleted, false = branch not deleted."
+        value: ${{ jobs.cleanup.outputs.branch-deleted }}
 
 jobs:
   cleanup:
@@ -32,7 +36,6 @@ jobs:
 
             # Check info of the branch
             gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
-            echo ""
 
             if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
               echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -4,17 +4,39 @@ on:
   workflow_call:
     inputs:
       branch:
-        description: "branch name to delete"
+        description: "branch name to delete. Only delete branches that are created by github-actions[bot] and are not the default branch."
         required: true
         type: string
 
 jobs:
   cleanup:
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check branch is deletable
+        id: check-branch
+        run: |
+          # Check if the branch is the default branch
+          if [[ "$(gh api /repos/${{ github.repository }} | jq -r '.default_branch')" == "${{ inputs.branch }}" ]]; then
+            echo "Branch is default, you cannot delete this branch. branch: ${{ inputs.branch }}"
+            exit 1
+          fi
+
+          # Check if the branch is created by github-actions[bot]
+          if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}"; then
+            if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
+              echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"
+              exit 1
+            fi
+
+            branch_deletable=true
+          else
+            branch_deletable=false
+          fi
+
+          echo "deletable=${branch_deletable}" | tee -a "${GITHUB_OUTPUT}"
       - name: Delete branch
-        uses: dawidd6/action-delete-branch@v3
-        with:
-          github_token: ${{ github.token }}
-          branches: ${{ inputs.branch }}
+        if: ${{ steps.check-branch.outputs.deletable == 'true' }}
+        run: gh api -X DELETE /repos/${{ github.repository }}/git/refs/heads/${{ inputs.branch }}

--- a/.github/workflows/clean-packagejson-branch.yaml
+++ b/.github/workflows/clean-packagejson-branch.yaml
@@ -28,7 +28,7 @@ jobs:
           if gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ inputs.branch }}"; then
             if [[ "$(gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq -r '.commit.author.login')" != "github-actions[bot]" ]]; then
               echo "Branch is not created by github-actions[bot], you cannot delete this branch. branch: ${{ inputs.branch }}"
-              gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }}
+              gh api /repos/${{ github.repository }}/branches/${{ inputs.branch }} | jq
               exit 1
             fi
 

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -49,7 +49,10 @@ jobs:
         run: |
           # list branch
           gh api /repos/${{ github.repository }}/branches | jq
-          echo ""
+
+          # debug
+          echo "DEBUG: cleanup : ${{ needs.cleanup.outputs.branch-deleted }}"
+          echo "DEBUG: cleanup2: ${{ needs.cleanup2.outputs.branch-deleted }}"
 
           # test
           echo -n "FACT: cleanup deleted branch. "

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -35,8 +35,14 @@ jobs:
     with:
       branch: ${{ needs.create-branch.outputs.branch-name }}
 
+  cleanup2:
+    needs: [create-branch]
+    uses: ./.github/workflows/clean-packagejson-branch.yaml
+    with:
+      branch: ${{ needs.create-branch.outputs.branch-name }}
+
   test:
-    needs: [create-branch, cleanup]
+    needs: [create-branch, cleanup, cleanup2]
     runs-on: ubuntu-latest
     steps:
       - name: Test branch deleted
@@ -46,6 +52,11 @@ jobs:
           echo ""
 
           # test
+          echo -n "FACT: cleanup deleted branch. "
+          [[ "${{ needs.cleanup.outputs.branch-deleted }}" == "true" ]] echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+          echo -n "FACT: cleanup2 skip delete branch. "
+          [[ "${{ needs.cleanup2.outputs.branch-deleted }}" != "true" ]] echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+
           echo -n "FACT: remote branch should not exists. "
           if ! gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ needs.create-branch.outputs.branch-name }}" >/dev/null; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
 

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -10,28 +10,33 @@ on:
 jobs:
   create-branch:
     runs-on: ubuntu-latest
+    outputs:
+      branch-name: ${{ steps.branch.outputs.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set branch name
+        id: branch
+        run: echo "name=test-branch-${{ github.run_id }}" | tee -a "$GITHUB_OUTPUT"
       - name: Add some file change
         run: echo "test" > test.txt
       - name: Create branch
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git switch -c test-branch-${{ github.run_id }}
+          git switch -c ${{ steps.branch.outputs.name }}
           git add .
           git commit -m "test"
-          git push origin test-branch-${{ github.run_id }}
+          git push origin ${{ steps.branch.outputs.name }}
 
   cleanup:
     needs: [create-branch]
     uses: ./.github/workflows/clean-packagejson-branch.yaml
     with:
-      branch: test-branch-${{ github.run_id }}
+      branch: ${{ needs.create-branch.outputs.branch-name }}
 
   test:
-    needs: [cleanup]
+    needs: [create-branch, cleanup]
     runs-on: ubuntu-latest
     steps:
       - name: Test branch deleted
@@ -42,9 +47,9 @@ jobs:
 
           # test
           echo -n "FACT: remote branch should not exists. "
-          if ! gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "test-branch-${{ github.run_id }}" >/dev/null; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+          if ! gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ needs.create-branch.outputs.branch-name }}" >/dev/null; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
 
           echo -n "FACT: remote branch should not retrieve. "
-          if ! gh api /repos/${{ github.repository }}/branches/test-branch-${{ github.run_id }} >/dev/null 2>&1; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+          if ! gh api /repos/${{ github.repository }}/branches/${{ needs.create-branch.outputs.branch-name }} >/dev/null 2>&1; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Create branch
         run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git checkout -b test-branch-${{ github.run_id }}
           git push origin test-branch-${{ github.run_id }}
 

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -41,4 +41,4 @@ jobs:
           echo -n "FACT: remote branch should not retrieve. "
           if ! gh api /repos/${{ github.repository }}/branches/test-branch-${{ github.run_id }} >/dev/null 2>&1; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -45,16 +45,13 @@ jobs:
     needs: [create-branch, cleanup, cleanup2]
     runs-on: ubuntu-latest
     steps:
+      - name: Branch list
+        run: gh api /repos/${{ github.repository }}/branches | jq
       - name: Test branch deleted
         run: |
-          # list branch
-          gh api /repos/${{ github.repository }}/branches | jq
-
-          # debug
           echo "DEBUG: cleanup : ${{ needs.cleanup.outputs.branch-deleted }}"
           echo "DEBUG: cleanup2: ${{ needs.cleanup2.outputs.branch-deleted }}"
 
-          # test
           echo -n "FACT: cleanup deleted branch. "
           [[ "${{ needs.cleanup.outputs.branch-deleted }}" == "true" ]] && echo "[O PASS]" || (echo "[X FAIL]" && exit 1)
           echo -n "FACT: cleanup2 skip delete branch. "

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -36,7 +36,7 @@ jobs:
       branch: ${{ needs.create-branch.outputs.branch-name }}
 
   cleanup2:
-    needs: [create-branch]
+    needs: [create-branch, cleanup]
     uses: ./.github/workflows/clean-packagejson-branch.yaml
     with:
       branch: ${{ needs.create-branch.outputs.branch-name }}

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -12,12 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Add some file change
+        run: echo "test" > test.txt
       - name: Create branch
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git checkout -b test-branch-${{ github.run_id }}
+          git switch -c test-branch-${{ github.run_id }}
+          git add .
+          git commit -m "test"
           git push origin test-branch-${{ github.run_id }}
 
   cleanup:

--- a/.github/workflows/test-clean-packagejson-branch.yaml
+++ b/.github/workflows/test-clean-packagejson-branch.yaml
@@ -56,9 +56,9 @@ jobs:
 
           # test
           echo -n "FACT: cleanup deleted branch. "
-          [[ "${{ needs.cleanup.outputs.branch-deleted }}" == "true" ]] echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+          [[ "${{ needs.cleanup.outputs.branch-deleted }}" == "true" ]] && echo "[O PASS]" || (echo "[X FAIL]" && exit 1)
           echo -n "FACT: cleanup2 skip delete branch. "
-          [[ "${{ needs.cleanup2.outputs.branch-deleted }}" != "true" ]] echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi
+          [[ "${{ needs.cleanup2.outputs.branch-deleted }}" != "true" ]] && echo "[O PASS]" || (echo "[X FAIL]" && exit 1)
 
           echo -n "FACT: remote branch should not exists. "
           if ! gh api /repos/${{ github.repository }}/branches | jq -r '.[].name' | grep "${{ needs.create-branch.outputs.branch-name }}" >/dev/null; then echo "[O PASS]"; else echo "[X FAIL]" && exit 1; fi

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.53"
+version="1.0.55"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.55"
+version="1.0.59"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.51"
+version="1.0.53"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.59"
+version="1.0.60"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
+++ b/Sandbox/Sandbox.Godot/addons/Foo/plugin.cfg
@@ -3,6 +3,6 @@
 name="Sandbox.Godot"
 description="Sample."
 author="Cysharp"
-version="1.0.60"
+version="1.0.61"
 language="C-sharp"
 script="GodotPlugin.cs"

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.55",
+  "version": "1.0.59",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.51",
+  "version": "1.0.53",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo.Plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.plugin.example",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "displayName": "Package Example Plugin",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.55",
+  "version": "1.0.59",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.53",
+  "version": "1.0.55",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",

--- a/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
+++ b/Sandbox/Sandbox.Unity/Assets/Plugins/Foo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.unity.example",
-  "version": "1.0.51",
+  "version": "1.0.53",
   "displayName": "Package Example",
   "description": "This is an example package",
   "unity": "2019.1",


### PR DESCRIPTION
## tl;dr;

`dawidd6/action-delete-branch` is archived. Change branch deletion to manual handling.

Old
* delete branch whenever possible

New
* check branch is delete-able.
  * default branch cannot delete.
  * NOT bot created branch cannot delete.
* Delete branch via API. It can handle without checkout.