### PR TITLE
ci: release-format to specify Release Name format when using.

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,11 +45,11 @@ on:
         required: false
         type: boolean
         default: false
-      release-prefix:
-        description: "Release prefix. (if 'Ver.' is specified, the release title will be 'Ver.1.0.0'. set '' if no prefix is preffered.)"
+      release-format:
+        description: "Release format. (if 'Ver.{0}' is specified, the release title will be 'Ver.1.0.0'. set '{0}' if no prefix is preferred.)"
         required: false
         type: string
-        default: 'Ver.'
+        default: 'Ver.{0}'
       # nuget
       nuget-push:
         description: "true = upload nuget package. false = not upload"
@@ -159,7 +159,12 @@ jobs:
           git tag ${{ inputs.tag }}
           git push origin ${{ inputs.tag }}
       - name: Create Release
-        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ inputs.release-prefix }}${{ inputs.tag }}" --generate-notes
+        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ format(inputs.release-format, inputs.tag) }}" --generate-notes
+      - name: Verify Release Name is expected
+        run: |
+          actual=$(gh api /repos/${{ github.repository }}/releases --jq '.[] | select(.tag_name=="${{ inputs.tag }}") | .name')
+          expected="${{ format(inputs.release-format, inputs.tag) }}"
+          if [[ "$actual" != "$expected" ]]; then echo "Release name is not as expected. expected: $expected, actual: $actual"; exit 1; fi
       - name: Upload asset files to release
         run: |
           while read -r asset_path; do

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      release-prefix:
+        description: "Release prefix. (if 'Ver.' is specified, the release title will be 'Ver.1.0.0'. set '' if no prefix is preffered.)"
+        required: false
+        type: string
+        default: 'Ver.'
       # nuget
       nuget-push:
         description: "true = upload nuget package. false = not upload"
@@ -154,7 +159,7 @@ jobs:
           git tag ${{ inputs.tag }}
           git push origin ${{ inputs.tag }}
       - name: Create Release
-        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "Ver.${{ inputs.tag }}" --generate-notes
+        run: gh release create ${{ inputs.tag }} --draft --verify-tag --title "${{ inputs.release-prefix }}${{ inputs.tag }}" --generate-notes
       - name: Upload asset files to release
         run: |
           while read -r asset_path; do

--- a/.github/workflows/test-create-release.yaml
+++ b/.github/workflows/test-create-release.yaml
@@ -101,6 +101,15 @@ jobs:
         ./nuget/ClassLibrary.${{ needs.set-tag.outputs.tag }}.nupkg
         ./nuget/ClassLibrary.${{ needs.set-tag.outputs.tag }}.snupkg
 
+  create-release2:
+    needs: [set-tag, update-packagejson, build-dotnet, build-unity, create-release]
+    uses: ./.github/workflows/create-release.yaml
+    with:
+      commit-id: ${{ needs.update-packagejson.outputs.sha }}
+      tag: ${{ needs.set-tag.outputs.tag }}
+      dry-run: true # true = Release作成後に60秒待って削除される。
+      release-format: '{0}'
+
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
     needs: [update-packagejson]


### PR DESCRIPTION
## tl;dr;

Some repository don't want use `Ver.1.0.0` style but want to use `1.0.0` style. `release-format` provide how to format release name.