### PR TITLE
feat: handle release check for over 100 releases

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -195,7 +195,7 @@ jobs:
       - name: Wait and Verify Release Name is expected
         run: |
           sleep 5s
-          actual=$(gh api /repos/${{ github.repository }}/releases?per_page=100 --jq ".[] | select(.tag_name==\"${{ inputs.tag }}\") | .name")
+          actual=$(gh api --pagenate /repos/${{ github.repository }}/releases?per_page=100 --jq '.[] | select(.tag_name == "${{ inputs.tag }}") | .name')
           expected="${{ format(inputs.release-format, inputs.tag) }}"
           if [[ "$actual" != "$expected" ]]; then echo "Release name is not as expected. expected: $expected, actual: $actual"; exit 1; fi
       - name: Upload asset files to release


### PR DESCRIPTION
## tl;dr;

There are 100 releases limit on create-release's release check. This PR fix with support pagenation.