### PR TITLE
fix: version replacement affects to nested version key

### DIFF
--- a/src/CysharpActions.Tests/UpdateVersionContentsTest.cs
+++ b/src/CysharpActions.Tests/UpdateVersionContentsTest.cs
@@ -21,4 +21,68 @@ public class UpdateVersionContentsTest
 
         Assert.Contains("version.txt", exception.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void UpdateUpmChangesOnlyRootVersionTest()
+    {
+        const string contents = """
+            {
+              "version": "1.0.0",
+              "metadata": {
+                "version": "schema-1"
+              }
+            }
+            """;
+
+        var updated = UpdateVersionCommand.UpdateContents("package.json", contents, "2.0.0");
+
+        Assert.Equal("""
+            {
+              "version": "2.0.0",
+              "metadata": {
+                "version": "schema-1"
+              }
+            }
+            """, updated);
+    }
+
+    [Fact]
+    public void UpdateGodotChangesOnlyPluginVersionTest()
+    {
+        const string contents = """
+            [application]
+            version="application-1"
+
+            [plugin]
+            minimum_version="4.0"
+            version="1.0.0"
+
+            [other]
+            version="other-1"
+            """;
+
+        var updated = UpdateVersionCommand.UpdateContents("plugin.cfg", contents, "2.0.0");
+
+        Assert.Equal("""
+            [application]
+            version="application-1"
+
+            [plugin]
+            minimum_version="4.0"
+            version="2.0.0"
+
+            [other]
+            version="other-1"
+            """, updated);
+    }
+
+    [Fact]
+    public void UpdateDirectoryBuildPropsPreservesMultipleVersionPrefixElementsTest()
+    {
+        const string contents = "<Project><PropertyGroup><VersionPrefix>1.0.0</VersionPrefix><Other>keep</Other><VersionPrefix>1.1.0</VersionPrefix></PropertyGroup></Project>";
+
+        var updated = UpdateVersionCommand.UpdateContents("Directory.Build.props", contents, "2.0.0");
+
+        Assert.Equal("<Project><PropertyGroup><VersionPrefix>2.0.0</VersionPrefix><Other>keep</Other><VersionPrefix>2.0.0</VersionPrefix></PropertyGroup></Project>", updated);
+    }
 }

--- a/src/CysharpActions/Commands/UpdateVersionCommand.cs
+++ b/src/CysharpActions/Commands/UpdateVersionCommand.cs
@@ -107,7 +107,7 @@ public sealed class UpdateVersionCommand
         var packageJson = JsonSerializer.Deserialize(after, JsonSourceGenerationContext.Default.UpmPackageJson) ??
                           throw new ActionCommandException($"UPM package.json updated, but failed to load as valid JSON. contents: {after}");
         if (packageJson.Version != version)
-            throw new ActionCommandException($"UPM package.json updated, but version miss-match. actual {packageJson.Version}, expected {version}");
+            throw new ActionCommandException($"UPM package.json updated, but version mismatch. actual {packageJson.Version}, expected {version}");
         return after;
     }
 
@@ -157,7 +157,7 @@ public sealed class UpdateVersionCommand
         foreach (System.Xml.XmlNode versionPrefixNode in versionPrefixNodes)
         {
             if (versionPrefixNode.InnerText != version)
-                throw new ActionCommandException($"Directory.Build.props updated, but version miss-match. actual {versionPrefixNode.InnerText}, expected {version}");
+                throw new ActionCommandException($"Directory.Build.props updated, but version mismatch. actual {versionPrefixNode.InnerText}, expected {version}");
         }
         return after;
     }

--- a/src/CysharpActions/Commands/UpdateVersionCommand.cs
+++ b/src/CysharpActions/Commands/UpdateVersionCommand.cs
@@ -1,6 +1,8 @@
 using CysharpActions.Contexts;
 using CysharpActions.Utils;
+using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace CysharpActions.Commands;
 
@@ -71,7 +73,37 @@ public sealed class UpdateVersionCommand
 
     private static string UpdateUpm(string contents, string version)
     {
-        var (_, after) = RegrexReplace.Replace(contents, @"""version"":\s*""(.*?)""", $@"""version"": ""{version}""");
+        var utf8 = Encoding.UTF8.GetBytes(contents);
+        var reader = new Utf8JsonReader(utf8);
+        var replacementStart = -1;
+        var valueEnd = -1;
+        while (reader.Read())
+        {
+            if (reader.TokenType != JsonTokenType.PropertyName ||
+                reader.CurrentDepth != 1 ||
+                !reader.ValueTextEquals("version"))
+            {
+                continue;
+            }
+
+            replacementStart = checked((int)reader.TokenStartIndex);
+            if (!reader.Read() || reader.TokenType != JsonTokenType.String)
+                throw new ActionCommandException("UPM package.json version must be a string.");
+
+            valueEnd = checked((int)reader.BytesConsumed);
+            break;
+        }
+
+        if (replacementStart < 0)
+            throw new ActionCommandException("UPM package.json version key not found.");
+
+        var replacement = Encoding.UTF8.GetBytes($"\"version\": {JsonSerializer.Serialize(version)}");
+        var updatedUtf8 = new byte[utf8.Length - (valueEnd - replacementStart) + replacement.Length];
+        utf8.AsSpan(0, replacementStart).CopyTo(updatedUtf8);
+        replacement.CopyTo(updatedUtf8.AsSpan(replacementStart));
+        utf8.AsSpan(valueEnd).CopyTo(updatedUtf8.AsSpan(replacementStart + replacement.Length));
+        var after = Encoding.UTF8.GetString(updatedUtf8);
+
         var packageJson = JsonSerializer.Deserialize(after, JsonSourceGenerationContext.Default.UpmPackageJson) ??
                           throw new ActionCommandException($"UPM package.json updated, but failed to load as valid JSON. contents: {after}");
         if (packageJson.Version != version)
@@ -81,34 +113,52 @@ public sealed class UpdateVersionCommand
 
     private static string UpdateGodot(string contents, string version)
     {
-        var (_, after) = RegrexReplace.Replace(contents, @"(version=)""(.*?)""", $@"$1""{version}""");
-        foreach (var line in after.Split('\n'))
-        {
-            if (!line.StartsWith("version=", StringComparison.Ordinal))
-                continue;
+        if (version.IndexOfAny(['"', '\r', '\n']) >= 0)
+            throw new ActionCommandException("Godot plugin.cfg version contains an invalid character.");
 
-            Span<Range> destination = stackalloc Range[2];
-            var span = line.AsSpan();
-            if (span.Split(destination, '=', StringSplitOptions.TrimEntries) != 2)
-                continue;
+        var sectionHeader = Regex.Match(contents, @"^[ \t]*\[plugin\][ \t]*\r?$", RegexOptions.Multiline);
+        if (!sectionHeader.Success)
+            throw new ActionCommandException("Godot plugin.cfg [plugin] section not found.");
 
-            var versionValue = span[destination[1]].ToString();
-            if (versionValue != $"\"{version}\"")
-                throw new ActionCommandException($"Godot plugin.cfg updated, but version miss-match. actual {versionValue}, expected {version}");
-            return after;
-        }
-        throw new ActionCommandException("Godot plugin.cfg updated, but version key not found.");
+        var sectionStart = sectionHeader.Index + sectionHeader.Length;
+        var nextSection = Regex.Match(
+            contents,
+            @"^[ \t]*\[[^\]\r\n]+\][ \t]*\r?$",
+            RegexOptions.Multiline,
+            TimeSpan.FromSeconds(1));
+        while (nextSection.Success && nextSection.Index <= sectionHeader.Index)
+            nextSection = nextSection.NextMatch();
+
+        var sectionEnd = nextSection.Success ? nextSection.Index : contents.Length;
+        var section = contents[sectionStart..sectionEnd];
+        var versionMatch = Regex.Match(
+            section,
+            @"^(?<prefix>[ \t]*version[ \t]*=[ \t]*)""(?<value>[^""\r\n]*)""",
+            RegexOptions.Multiline);
+        if (!versionMatch.Success)
+            throw new ActionCommandException("Godot plugin.cfg version key not found in [plugin] section.");
+
+        var value = versionMatch.Groups["value"];
+        var valueStart = sectionStart + value.Index;
+        return contents[..valueStart] + version + contents[(valueStart + value.Length)..];
     }
 
     private static string UpdateDirectoryBuildProps(string contents, string version)
     {
-        var (_, after) = RegrexReplace.Replace(contents, @"<VersionPrefix>.*</VersionPrefix>", $@"<VersionPrefix>{version}</VersionPrefix>");
+        var after = Regex.Replace(
+            contents,
+            @"(?<=<VersionPrefix>)[^<]*(?=</VersionPrefix>)",
+            _ => version);
         var xmlDoc = new System.Xml.XmlDocument();
         xmlDoc.LoadXml(after);
-        var versionPrefixNode = xmlDoc.SelectSingleNode("//VersionPrefix") ??
-                                throw new ActionCommandException("Directory.Build.props updated, but VersionPrefix key not found.");
-        if (versionPrefixNode.InnerText != version)
-            throw new ActionCommandException($"Directory.Build.props updated, but version miss-match. actual {versionPrefixNode.InnerText}, expected {version}");
+        var versionPrefixNodes = xmlDoc.SelectNodes("//VersionPrefix");
+        if (versionPrefixNodes == null || versionPrefixNodes.Count == 0)
+            throw new ActionCommandException("Directory.Build.props updated, but VersionPrefix key not found.");
+        foreach (System.Xml.XmlNode versionPrefixNode in versionPrefixNodes)
+        {
+            if (versionPrefixNode.InnerText != version)
+                throw new ActionCommandException($"Directory.Build.props updated, but version miss-match. actual {versionPrefixNode.InnerText}, expected {version}");
+        }
         return after;
     }
 


### PR DESCRIPTION
## Summary

- Update only the root `version` field in UPM `package.json`.
- Update only the `version` key in Godot’s `[plugin]` section.
- Safely update multiple `VersionPrefix` elements without removing surrounding XML.
- Add regression tests for each case.

## Intent

Prevent unintended file modifications while preserving existing formatting and version-update behavior.

## Fixed Examples

Let's think update 1.0.0 -> 2.0.0

### UPM `package.json`

Previously, every property named `version` was updated, including nested metadata.

```json
{
  "version": "1.0.0",
  "metadata": {
    "version": "schema-1" // also become 2.0.0
  }
}
```

Now only the root package version is updated:

```json
{
  "version": "2.0.0",
  "metadata": {
    "version": "schema-1"
  }
}
```

### Godot `plugin.cfg`

Previously, version-like keys and `version` keys outside the plugin section could also be changed.

```ini
[application]
version="application-1"

[plugin]
minimum_version="4.0" // also become 2.0.0
version="1.0.0"

[other]
version="other-1"
```

Now only the plugin version is updated:

```ini
[application]
version="application-1"

[plugin]
minimum_version="4.0"
version="2.0.0"

[other]
version="other-1"
```

### `Directory.Build.props`

Previously, multiple `VersionPrefix` elements on the same line could cause the content between them to be removed.

```xml
<Project><PropertyGroup><VersionPrefix>1.0.0</VersionPrefix><Other>keep</Other><VersionPrefix>1.1.0</VersionPrefix></PropertyGroup></Project>
```

Now both version elements are updated while the surrounding XML is preserved:

```xml
<Project><PropertyGroup><VersionPrefix>2.0.0</VersionPrefix><Other>keep</Other><VersionPrefix>2.0.0</VersionPrefix></PropertyGroup></Project>
```

